### PR TITLE
Improvements to TTL (expiration) support

### DIFF
--- a/benchmark_dcp.py
+++ b/benchmark_dcp.py
@@ -23,7 +23,7 @@ workload_settings = type(
                          
                          'size': 2048,
                          'items': 10000,
-                         'expiration': 0,
+                         'expiration_pnct': 0,
                          'working_set': 100,
                          'working_set_access': 100,
                          

--- a/benchmark_docs.py
+++ b/benchmark_docs.py
@@ -8,7 +8,7 @@ from spring.docgen import NewNestedDocument, NewKey
 
 
 def generate_keys():
-    new_keys = NewKey(prefix=None, expiration=0)
+    new_keys = NewKey(prefix=None)
     return tuple(new_keys.next(i)[0] for i in xrange(50000))
 
 

--- a/benchmark_ops.py
+++ b/benchmark_ops.py
@@ -23,7 +23,7 @@ workload_settings = type(
 
         'size': 2048,
         'items': 10000,
-        'expiration': 0,
+        'expiration_pcnt': 0,
         'working_set': 100,
         'working_set_access': 100,
 

--- a/spring/__main__.py
+++ b/spring/__main__.py
@@ -42,8 +42,12 @@ class CLIParser(ArgumentParser):
             help='percentage of "delete" operations (0 by default)',
         )
         self.add_argument(
-            '-e', dest='expiration', type=int, default=0, metavar='',
+            '-e', dest='expiration_pcnt', type=float, default=0.0, metavar='',
             help='percentage of new items that expire (0 by default)',
+        )
+        self.add_argument(
+            '-E', dest='expiration_ttl', type=int, default=10, metavar='',
+            help='for new items that expire, TTL to use (seconds, 10 by default)'
         )
         self.add_argument(
             '-o', dest='ops', type=int, default=float('inf'), metavar='',
@@ -96,7 +100,7 @@ class CLIParser(ArgumentParser):
         if not 0 <= args.working_set <= 100:
             self.error('Invalid working set [-w] percentage.')
 
-        if not 0 <= args.expiration <= 100:
+        if not 0 <= args.expiration_pcnt <= 100:
             self.error('Invalid expiration [-e] percentage.')
 
         if not 0 <= args.working_set_access <= 100:

--- a/spring/cbgen.py
+++ b/spring/cbgen.py
@@ -36,15 +36,15 @@ class CBAsyncGen(object):
 
     def create(self, key, doc, ttl=None):
         extra_params = {}
-        if ttl is None:
+        if ttl:
             extra_params['ttl'] = ttl
         return self.client.set(key, doc, **extra_params)
 
     def read(self, key):
         return self.client.get(key)
 
-    def update(self, key, doc):
-        return self.client.set(key, doc)
+    def update(self, key, doc, ttl=None):
+        return self.create(key, doc, ttl)
 
     def cas(self, key, doc):
         cas = self.client.get(key).cas

--- a/spring/docgen.py
+++ b/spring/docgen.py
@@ -80,7 +80,7 @@ class NewKey(Iterator):
         key = '%012d' % curr_items
         key = self.add_prefix(key)
         ttl = None
-        if self.expiration and random.randint(1, 100) <= self.expiration:
+        if self.expiration and random.random() < self.expiration:
             ttl = self.ttls.next()
         return key, ttl
 

--- a/spring/settings.py
+++ b/spring/settings.py
@@ -18,7 +18,8 @@ class WorkloadSettings(object):
         self.doc_gen = options.generator
         self.size = options.size
         self.items = options.items
-        self.expiration = options.expiration
+        self.expiration_pcnt = options.expiration_pcnt
+        self.expiration_ttl = options.expiration_ttl
         self.working_set = options.working_set
         self.working_set_access = options.working_set_access
 

--- a/spring/wgen.py
+++ b/spring/wgen.py
@@ -42,8 +42,10 @@ class Worker(object):
         self.existing_keys = ExistingKey(self.ws.working_set,
                                          self.ws.working_set_access,
                                          self.ts.prefix,
-                                         self.ws.expiration)
-        self.new_keys = NewKey(self.ts.prefix, self.ws.expiration)
+                                         self.ws.expiration_pcnt,
+                                         self.ws.expiration_ttl)
+        self.new_keys = NewKey(self.ts.prefix, self.ws.expiration_pcnt,
+                               self.ws.expiration_ttl)
         self.keys_for_removal = KeyForRemoval(self.ts.prefix)
 
         if not hasattr(self.ws, 'doc_gen') or self.ws.doc_gen == 'old':


### PR DESCRIPTION
Two changes to improve support for specifying TTLs (expiration) for documents:
- Allow TTLs to be optionally set for Existing documents (i.e. updates). Previously only new documents could be given a TTL.
- Change the type of the expiration likelihood from an integer percentage to a fraction. This permits specifying less than 1% of mutations to have a TTL set.
